### PR TITLE
Adding ability to change edgecolors and linewidths

### DIFF
--- a/ase/io/utils.py
+++ b/ase/io/utils.py
@@ -10,11 +10,29 @@ from ase.data.colors import jmol_colors
 
 class PlottingVariables:
     # removed writer - self
-    def __init__(self, atoms, rotation='', show_unit_cell=2,
-                 radii=None, bbox=None, colors=None, scale=20,
-                 maxwidth=500, extra_offset=(0., 0.)):
+    def __init__(
+        self,
+        atoms,
+        rotation="",
+        show_unit_cell=2,
+        radii=None,
+        bbox=None,
+        colors=None,
+        edgecolors="black",
+        linewidths=1,
+        scale=20,
+        maxwidth=500,
+        extra_offset=(0.0, 0.0),
+    ):
         self.numbers = atoms.get_atomic_numbers()
         self.colors = colors
+        self.edgecolors = edgecolors
+        if not isinstance(edgecolors, (list, np.ndarray)):
+            self.edgecolors = [edgecolors for _ in self.numbers]
+        self.linewidths = linewidths
+        if not isinstance(linewidths, (list, np.ndarray)):
+            self.linewidths = [linewidths for _ in self.numbers]
+
         if colors is None:
             ncolors = len(jmol_colors)
             self.colors = jmol_colors[self.numbers.clip(max=ncolors - 1)]
@@ -182,8 +200,13 @@ def make_patch_list(writer):
                                        key=lambda x: x[1],
                                        reverse=True):
                     if np.round(occ, decimals=4) == 1.0:
-                        patch = Circle(xy, r, facecolor=writer.colors[a],
-                                       edgecolor='black')
+                        patch = Circle(
+                            xy,
+                            r,
+                            facecolor=writer.colors[a],
+                            edgecolor=writer.edgecolors[a],
+                            linewidth=writer.linewidths[a],
+                        )
                         patch_list.append(patch)
                     else:
                         # jmol colors for the moment
@@ -196,10 +219,19 @@ def make_patch_list(writer):
                         start += extent
 
             else:
-                if ((xy[1] + r > 0) and (xy[1] - r < writer.h) and
-                    (xy[0] + r > 0) and (xy[0] - r < writer.w)):
-                    patch = Circle(xy, r, facecolor=writer.colors[a],
-                                   edgecolor='black')
+                if (
+                    (xy[1] + r > 0)
+                    and (xy[1] - r < writer.h)
+                    and (xy[0] + r > 0)
+                    and (xy[0] - r < writer.w)
+                ):
+                    patch = Circle(
+                        xy,
+                        r,
+                        facecolor=writer.colors[a],
+                        edgecolor=writer.edgecolors[a],
+                        linewidth=writer.linewidths[a],
+                    )
                     patch_list.append(patch)
         else:
             a -= writer.natoms

--- a/ase/test/test_matplotlib_plot.py
+++ b/ase/test/test_matplotlib_plot.py
@@ -25,6 +25,17 @@ def test_matplotlib_plot(plt):
     assert len(ax.patches) == len(slab)
 
 
+def test_matplotlib_edgecolors(plt):
+    slab = FaceCenteredCubic('Au', size=(2, 2, 2))
+
+    fig, ax = plt.subplots()
+    edgecolors=np.random.uniform(0, 1, (len(slab), 4))
+    plot_atoms(slab, ax, radii=0.5,
+               show_unit_cell=0, edgecolors=edgecolors)
+
+    for p, ec in zip(ax.patches, edgecolors[np.argsort(slab.positions[:, 2])]):
+        assert np.allclose(p._edgecolor, ec, atol=1E-4)
+
 class TestPlotManager:
     @pytest.fixture
     def xy_data(self):

--- a/ase/visualize/plot.py
+++ b/ase/visualize/plot.py
@@ -2,13 +2,31 @@ from ase.io.utils import PlottingVariables, make_patch_list
 
 
 class Matplotlib(PlottingVariables):
-    def __init__(self, atoms, ax,
-                 rotation='', radii=None,
-                 colors=None, scale=1, offset=(0, 0), **parameters):
+    def __init__(
+        self,
+        atoms,
+        ax,
+        rotation="",
+        radii=None,
+        colors=None,
+        edgecolors="black",
+        linewidths=1,
+        scale=1,
+        offset=(0, 0),
+        **parameters
+    ):
         PlottingVariables.__init__(
-            self, atoms, rotation=rotation,
-            radii=radii, colors=colors, scale=scale,
-            extra_offset=offset, **parameters)
+            self,
+            atoms,
+            rotation=rotation,
+            radii=radii,
+            colors=colors,
+            edgecolors=edgecolors,
+            linewidths=linewidths,
+            scale=scale,
+            extra_offset=offset,
+            **parameters
+        )
 
         self.ax = ax
         self.figure = ax.figure
@@ -82,6 +100,10 @@ def plot_atoms(atoms, ax=None, **parameters):
     colors : list of strings, optional
         Color of the atoms, must be the same length as
         the number of atoms in the atoms object.
+    edgecolors : string or list of strings, optional
+        linecolor of the atoms
+    linewidths : float or list of float, optional
+        linewidths for any bonds
     scale : float, optional
         Scaling of the plotted atoms and lines.
     offset : tuple (float, float), optional
@@ -92,6 +114,7 @@ def plot_atoms(atoms, ax=None, **parameters):
         atoms = atoms[0]
 
     import matplotlib.pyplot as plt
+
     if ax is None:
         ax = plt.gca()
     Matplotlib(atoms, ax, **parameters).write()


### PR DESCRIPTION
Hi! I am currently working on some visualizations where I need to "grey out" some atoms to highlight others. This is currently possible by changing the `alpha` value of the rgba colors, however, there isn't currently a way to also affect the `alpha` value of the edgecolors. Now users can pass a list of edgecolors or a single edgecolor to use for the atoms. Just like the `colors` parameter, this is only respected when working with complete occupancy.

This change does not affect the default functionality, just allows for some additional flexibility. I have added a test to make sure that the edgecolors are used in the order received.

I have also added similar functionality to play with the linewidths, which again should not change the default function.